### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ An MCP Server to communicate with Jira.
 
 This may work with Jira Data Center rest endpoints (`/rest/api/2`), but as of right now only cloud endpoints have been tested (`/rest/api/3`).
 
+<a href="https://glama.ai/mcp/servers/@brianstone/jira-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@brianstone/jira-mcp-server/badge" alt="Jira Server MCP server" />
+</a>
+
 ## Running the Server
 
 1. Clone this repo


### PR DESCRIPTION
This PR adds a badge for the [Jira MCP Server](https://glama.ai/mcp/servers/@brianstone/jira-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@brianstone/jira-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@brianstone/jira-mcp-server/badge" alt="Jira Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.